### PR TITLE
 made a couple of changes to make library python 3 compatible

### DIFF
--- a/louie/dispatcher.py
+++ b/louie/dispatcher.py
@@ -134,7 +134,7 @@ def connect(receiver, signal=All, sender=Any, weak=True):
     if weak:
         receiver = saferef.safe_ref(receiver, on_delete=_remove_receiver)
     senderkey = id(sender)
-    if connections.has_key(senderkey):
+    if senderkey in connections.keys():
         signals = connections[senderkey]
     else:
         connections[senderkey] = signals = {}
@@ -153,7 +153,7 @@ def connect(receiver, signal=All, sender=Any, weak=True):
     receiver_id = id(receiver)
     # get current set, remove any current references to
     # this receiver in the set, including back-references
-    if signals.has_key(signal):
+    if signal in signals.keys():
         receivers = signals[signal]
         _remove_old_back_refs(senderkey, signal, receiver, receivers)
     else:
@@ -454,7 +454,7 @@ def send_robust(signal=All, sender=Anonymous, *arguments, **named):
                 *arguments,
                 **named
                 )
-        except Exception, err:
+        except Exception as err:
             responses.append((receiver, err))
         else:
             responses.append((receiver, response))

--- a/louie/saferef.py
+++ b/louie/saferef.py
@@ -122,7 +122,7 @@ class BoundMethodWeakref(object):
                 except Exception:
                     try:
                         traceback.print_exc()
-                    except AttributeError, e:
+                    except AttributeError as e:
                         print ('Exception during saferef %s '
                                'cleanup function %s: %s' % (self, function, e))
         self.deletion_methods = [on_delete]


### PR DESCRIPTION
has_key() no longer in python 3, exceptions needed 'as' to be compatible to pass along Exception data in a compatible way.